### PR TITLE
feature/email

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
 
@@ -52,6 +53,7 @@ dependencies {
 
     /* stmp */
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-mail', version: '3.0.5'
+    implementation 'javax.mail:javax.mail-api:1.6.2'
 }
 
 dependencyManagement {

--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,9 @@ dependencies {
     /* redis */
     implementation("org.springframework.session:spring-session-data-redis")
     implementation 'io.lettuce:lettuce-core:6.2.3.RELEASE'
+
+    /* stmp */
+    implementation group: 'org.springframework.boot', name: 'spring-boot-starter-mail', version: '3.0.5'
 }
 
 dependencyManagement {

--- a/src/main/java/com/github/theia/adapter/email/in/presentation/EmailController.java
+++ b/src/main/java/com/github/theia/adapter/email/in/presentation/EmailController.java
@@ -1,6 +1,8 @@
 package com.github.theia.adapter.email.in.presentation;
 
 import com.github.theia.adapter.email.in.presentation.dto.request.EmailSendRequest;
+import com.github.theia.adapter.email.in.presentation.dto.request.EmailVerificationRequest;
+import com.github.theia.application.email.port.in.VerifyEmailUseCase;
 import com.github.theia.application.email.port.service.EmailService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -12,10 +14,21 @@ import org.springframework.web.bind.annotation.*;
 public class EmailController {
 
     private final EmailService emailService;
+    private final VerifyEmailUseCase verifyEmailUseCase;
 
     @PostMapping
     public ResponseEntity<Void> sendEmail(@RequestBody EmailSendRequest emailSendRequest) {
         emailService.sendEmail(emailSendRequest.getEmail(), "title", "text");
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/verify")
+    public ResponseEntity<Void> verifyEmail(@RequestBody EmailVerificationRequest emailVerificationRequest) {
+        String email = emailVerificationRequest.getEmail();
+        String code = emailVerificationRequest.getCode();
+
+        verifyEmailUseCase.verifyEmail(email, code);
+
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/github/theia/adapter/email/in/presentation/EmailController.java
+++ b/src/main/java/com/github/theia/adapter/email/in/presentation/EmailController.java
@@ -18,7 +18,7 @@ public class EmailController {
 
     @PostMapping
     public ResponseEntity<Void> sendEmail(@RequestBody EmailSendRequest emailSendRequest) {
-        emailService.sendEmail(emailSendRequest.getEmail(), "title", "text");
+        emailService.sendEmail(emailSendRequest.getEmail(), "[Theia] 이메일 인증");
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/github/theia/adapter/email/in/presentation/EmailController.java
+++ b/src/main/java/com/github/theia/adapter/email/in/presentation/EmailController.java
@@ -1,0 +1,21 @@
+package com.github.theia.adapter.email.in.presentation;
+
+import com.github.theia.adapter.email.in.presentation.dto.request.EmailSendRequest;
+import com.github.theia.application.email.port.service.EmailService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/email")
+public class EmailController {
+
+    private final EmailService emailService;
+
+    @PostMapping
+    public ResponseEntity<Void> sendEmail(@RequestBody EmailSendRequest emailSendRequest) {
+        emailService.sendEmail(emailSendRequest.getEmail(), "title", "text");
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/github/theia/adapter/email/in/presentation/dto/request/EmailSendRequest.java
+++ b/src/main/java/com/github/theia/adapter/email/in/presentation/dto/request/EmailSendRequest.java
@@ -1,0 +1,10 @@
+package com.github.theia.adapter.email.in.presentation.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class EmailSendRequest {
+    private String email;
+}

--- a/src/main/java/com/github/theia/adapter/email/in/presentation/dto/request/EmailVerificationRequest.java
+++ b/src/main/java/com/github/theia/adapter/email/in/presentation/dto/request/EmailVerificationRequest.java
@@ -1,0 +1,11 @@
+package com.github.theia.adapter.email.in.presentation.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class EmailVerificationRequest {
+    private String email;
+    private String code;
+}

--- a/src/main/java/com/github/theia/adapter/email/out/persistence/EmailAuthJpaRepository.java
+++ b/src/main/java/com/github/theia/adapter/email/out/persistence/EmailAuthJpaRepository.java
@@ -1,0 +1,7 @@
+package com.github.theia.adapter.email.out.persistence;
+
+import com.github.theia.domain.email.EmailAuthRedisEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EmailAuthJpaRepository extends JpaRepository<EmailAuthRedisEntity, String> {
+}

--- a/src/main/java/com/github/theia/adapter/email/out/persistence/EmailAuthJpaRepository.java
+++ b/src/main/java/com/github/theia/adapter/email/out/persistence/EmailAuthJpaRepository.java
@@ -1,7 +1,10 @@
 package com.github.theia.adapter.email.out.persistence;
 
 import com.github.theia.domain.email.EmailAuthRedisEntity;
-import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.CrudRepository;
 
-public interface EmailAuthJpaRepository extends JpaRepository<EmailAuthRedisEntity, String> {
+import java.util.Optional;
+
+public interface EmailAuthJpaRepository extends CrudRepository<EmailAuthRedisEntity, String> {
+    Optional<EmailAuthRedisEntity> findByEmail(String email);
 }

--- a/src/main/java/com/github/theia/adapter/email/out/persistence/EmailAuthRepository.java
+++ b/src/main/java/com/github/theia/adapter/email/out/persistence/EmailAuthRepository.java
@@ -1,0 +1,18 @@
+package com.github.theia.adapter.email.out.persistence;
+
+import com.github.theia.application.email.port.out.SaveEmailPort;
+import com.github.theia.domain.email.EmailAuthRedisEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class EmailAuthRepository implements SaveEmailPort {
+
+    private final EmailAuthJpaRepository emailAuthJpaRepository;
+
+    @Override
+    public EmailAuthRedisEntity save(EmailAuthRedisEntity emailAuthRedisEntity) {
+        return emailAuthJpaRepository.save(emailAuthRedisEntity);
+    }
+}

--- a/src/main/java/com/github/theia/adapter/email/out/persistence/EmailAuthRepository.java
+++ b/src/main/java/com/github/theia/adapter/email/out/persistence/EmailAuthRepository.java
@@ -1,18 +1,26 @@
 package com.github.theia.adapter.email.out.persistence;
 
+import com.github.theia.application.email.port.out.LoadEmailAuthByEmailPort;
 import com.github.theia.application.email.port.out.SaveEmailPort;
 import com.github.theia.domain.email.EmailAuthRedisEntity;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 @RequiredArgsConstructor
-public class EmailAuthRepository implements SaveEmailPort {
+public class EmailAuthRepository implements SaveEmailPort, LoadEmailAuthByEmailPort {
 
     private final EmailAuthJpaRepository emailAuthJpaRepository;
 
     @Override
     public EmailAuthRedisEntity save(EmailAuthRedisEntity emailAuthRedisEntity) {
         return emailAuthJpaRepository.save(emailAuthRedisEntity);
+    }
+
+    @Override
+    public Optional<EmailAuthRedisEntity> findByEmail(String email) {
+        return emailAuthJpaRepository.findByEmail(email);
     }
 }

--- a/src/main/java/com/github/theia/application/email/port/in/SendEmailUseCase.java
+++ b/src/main/java/com/github/theia/application/email/port/in/SendEmailUseCase.java
@@ -6,4 +6,5 @@ public interface SendEmailUseCase {
     void sendEmail(String toEmail, String title, String text);
 
     SimpleMailMessage createEmailForm(String toEmail, String title, String text);
+
 }

--- a/src/main/java/com/github/theia/application/email/port/in/SendEmailUseCase.java
+++ b/src/main/java/com/github/theia/application/email/port/in/SendEmailUseCase.java
@@ -3,5 +3,5 @@ package com.github.theia.application.email.port.in;
 import org.springframework.mail.SimpleMailMessage;
 
 public interface SendEmailUseCase {
-    void sendEmail(String toEmail, String title, String text);
+    void sendEmail(String toEmail, String title);
 }

--- a/src/main/java/com/github/theia/application/email/port/in/SendEmailUseCase.java
+++ b/src/main/java/com/github/theia/application/email/port/in/SendEmailUseCase.java
@@ -1,0 +1,9 @@
+package com.github.theia.application.email.port.in;
+
+import org.springframework.mail.SimpleMailMessage;
+
+public interface SendEmailUseCase {
+    void sendEmail(String toEmail, String title, String text);
+
+    SimpleMailMessage createEmailForm(String toEmail, String title, String text);
+}

--- a/src/main/java/com/github/theia/application/email/port/in/SendEmailUseCase.java
+++ b/src/main/java/com/github/theia/application/email/port/in/SendEmailUseCase.java
@@ -4,7 +4,4 @@ import org.springframework.mail.SimpleMailMessage;
 
 public interface SendEmailUseCase {
     void sendEmail(String toEmail, String title, String text);
-
-    SimpleMailMessage createEmailForm(String toEmail, String title, String text);
-
 }

--- a/src/main/java/com/github/theia/application/email/port/in/VerifyEmailUseCase.java
+++ b/src/main/java/com/github/theia/application/email/port/in/VerifyEmailUseCase.java
@@ -1,0 +1,5 @@
+package com.github.theia.application.email.port.in;
+
+public interface VerifyEmailUseCase {
+    void verifyEmail(String email, String code);
+}

--- a/src/main/java/com/github/theia/application/email/port/out/LoadEmailAuthByEmailPort.java
+++ b/src/main/java/com/github/theia/application/email/port/out/LoadEmailAuthByEmailPort.java
@@ -1,0 +1,9 @@
+package com.github.theia.application.email.port.out;
+
+import com.github.theia.domain.email.EmailAuthRedisEntity;
+
+import java.util.Optional;
+
+public interface LoadEmailAuthByEmailPort {
+    Optional<EmailAuthRedisEntity> findByEmail(String email);
+}

--- a/src/main/java/com/github/theia/application/email/port/out/SaveEmailPort.java
+++ b/src/main/java/com/github/theia/application/email/port/out/SaveEmailPort.java
@@ -1,0 +1,7 @@
+package com.github.theia.application.email.port.out;
+
+import com.github.theia.domain.email.EmailAuthRedisEntity;
+
+public interface SaveEmailPort {
+    EmailAuthRedisEntity save(EmailAuthRedisEntity emailAuthRedisEntity);
+}

--- a/src/main/java/com/github/theia/application/email/port/service/EmailService.java
+++ b/src/main/java/com/github/theia/application/email/port/service/EmailService.java
@@ -1,0 +1,41 @@
+package com.github.theia.application.email.port.service;
+
+import com.github.theia.application.email.port.in.SendEmailUseCase;
+import com.github.theia.global.error.exception.ErrorCode;
+import com.github.theia.global.error.exception.TheiaException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.github.theia.global.error.exception.ErrorCode.*;
+
+@Service
+@RequiredArgsConstructor
+public class EmailService implements SendEmailUseCase {
+
+    private final JavaMailSender emailSender;
+
+    @Override
+    @Transactional
+    public void sendEmail(String toEmail, String title, String text) {
+        SimpleMailMessage message = createEmailForm(toEmail, title, text);
+
+        try {
+            emailSender.send(message);
+        } catch (Exception e) {
+            throw new TheiaException(ERROR_EMAIL);
+        }
+    }
+
+    @Override
+    public SimpleMailMessage createEmailForm(String toEmail, String title, String text) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(toEmail);
+        message.setSubject(title);
+        message.setText(text);
+
+        return message;
+    }
+}

--- a/src/main/java/com/github/theia/application/email/port/service/EmailService.java
+++ b/src/main/java/com/github/theia/application/email/port/service/EmailService.java
@@ -1,13 +1,20 @@
 package com.github.theia.application.email.port.service;
 
 import com.github.theia.application.email.port.in.SendEmailUseCase;
-import com.github.theia.global.error.exception.ErrorCode;
+import com.github.theia.application.email.port.out.LoadEmailAuthByEmailPort;
+import com.github.theia.application.email.port.out.SaveEmailPort;
+import com.github.theia.domain.email.EmailAuthRedisEntity;
 import com.github.theia.global.error.exception.TheiaException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.Random;
 
 import static com.github.theia.global.error.exception.ErrorCode.*;
 
@@ -15,14 +22,35 @@ import static com.github.theia.global.error.exception.ErrorCode.*;
 @RequiredArgsConstructor
 public class EmailService implements SendEmailUseCase {
 
+    @Value("${spring.auth-code-expiration-millis}")
+    private Long authCodeExp;
+
+    private final SaveEmailPort saveEmailPort;
+    private final LoadEmailAuthByEmailPort loadEmailAuthByEmailPort;
     private final JavaMailSender emailSender;
 
     @Override
     @Transactional
     public void sendEmail(String toEmail, String title, String text) {
-        SimpleMailMessage message = createEmailForm(toEmail, title, text);
+
+        String code = createCode();
+
+        EmailAuthRedisEntity emailAuthRedisEntity = loadEmailAuthByEmailPort.findByEmail(toEmail)
+                .orElse(
+                        EmailAuthRedisEntity.builder()
+                            .email(toEmail)
+                            .code(code)
+                            .authentication(false)
+                            .expiredAt(authCodeExp)
+                            .build()
+                );
+
+        emailAuthRedisEntity.updateCode(code);
+
+        SimpleMailMessage message = createEmailForm(toEmail, title, code);
 
         try {
+            saveEmailPort.save(emailAuthRedisEntity);
             emailSender.send(message);
         } catch (Exception e) {
             throw new TheiaException(ERROR_EMAIL);
@@ -37,5 +65,20 @@ public class EmailService implements SendEmailUseCase {
         message.setText(text);
 
         return message;
+    }
+
+    private String createCode() {
+        int lenth = 6;
+        try {
+            Random random = SecureRandom.getInstanceStrong();
+            StringBuilder builder = new StringBuilder();
+            for (int i = 0; i < lenth; i++) {
+                builder.append(random.nextInt(10));
+            }
+
+            return builder.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new TheiaException(ERROR_CODE);
+        }
     }
 }

--- a/src/main/java/com/github/theia/application/email/port/service/EmailService.java
+++ b/src/main/java/com/github/theia/application/email/port/service/EmailService.java
@@ -84,11 +84,11 @@ public class EmailService implements SendEmailUseCase, VerifyEmailUseCase {
     }
 
     private String createCode() {
-        int lenth = 6;
+        int length = 6;
         try {
             Random random = SecureRandom.getInstanceStrong();
             StringBuilder builder = new StringBuilder();
-            for (int i = 0; i < lenth; i++) {
+            for (int i = 0; i < length; i++) {
                 builder.append(random.nextInt(10));
             }
 

--- a/src/main/java/com/github/theia/application/email/port/service/EmailService.java
+++ b/src/main/java/com/github/theia/application/email/port/service/EmailService.java
@@ -6,11 +6,9 @@ import com.github.theia.application.email.port.out.LoadEmailAuthByEmailPort;
 import com.github.theia.application.email.port.out.SaveEmailPort;
 import com.github.theia.domain.email.EmailAuthRedisEntity;
 import com.github.theia.global.error.exception.TheiaException;
-import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
@@ -29,7 +27,7 @@ import static com.github.theia.global.error.exception.ErrorCode.*;
 @RequiredArgsConstructor
 public class EmailService implements SendEmailUseCase, VerifyEmailUseCase {
 
-    @Value("${spring.auth-code-expiration-millis}")
+    @Value("${spring.codeExp}")
     private Long authCodeExp;
 
     private final SaveEmailPort saveEmailPort;
@@ -65,6 +63,7 @@ public class EmailService implements SendEmailUseCase, VerifyEmailUseCase {
             helper.setTo(email);
             helper.setSubject(title);
             helper.setText(createMailTemplate(code), true);
+
             saveEmailPort.save(emailAuthRedisEntity);
             emailSender.send(message);
         } catch (Exception e) {

--- a/src/main/java/com/github/theia/application/email/port/service/EmailService.java
+++ b/src/main/java/com/github/theia/application/email/port/service/EmailService.java
@@ -41,9 +41,14 @@ public class EmailService implements SendEmailUseCase {
                             .email(toEmail)
                             .code(code)
                             .authentication(false)
+                            .attemptCount(0)
                             .expiredAt(authCodeExp)
                             .build()
                 );
+
+        if (emailAuthRedisEntity.getAttemptCount() >= 5) {
+            throw new TheiaException(MANY_EMAIL);
+        }
 
         emailAuthRedisEntity.updateCode(code);
 

--- a/src/main/java/com/github/theia/domain/email/EmailAuthRedisEntity.java
+++ b/src/main/java/com/github/theia/domain/email/EmailAuthRedisEntity.java
@@ -16,10 +16,17 @@ public class EmailAuthRedisEntity {
     @Column(name = "email")
     private String email;
 
+    @Column(name = "code")
+    private String code;
+
     @Column(name = "authentication")
     private Boolean authentication;
 
     @TimeToLive
     @Column(name = "expired_at")
     private Long expiredAt;
+
+    public void updateCode(String code) {
+        this.code = code;
+    }
 }

--- a/src/main/java/com/github/theia/domain/email/EmailAuthRedisEntity.java
+++ b/src/main/java/com/github/theia/domain/email/EmailAuthRedisEntity.java
@@ -1,0 +1,25 @@
+package com.github.theia.domain.email;
+
+import jakarta.persistence.Column;
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+
+@RedisHash("emailAuth")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class EmailAuthRedisEntity {
+    @Id
+    @Column(name = "email")
+    private String email;
+
+    @Column(name = "authentication")
+    private Boolean authentication;
+
+    @TimeToLive
+    @Column(name = "expired_at")
+    private Long expiredAt;
+}

--- a/src/main/java/com/github/theia/domain/email/EmailAuthRedisEntity.java
+++ b/src/main/java/com/github/theia/domain/email/EmailAuthRedisEntity.java
@@ -5,6 +5,7 @@ import lombok.*;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
 import org.springframework.data.redis.core.TimeToLive;
+import org.springframework.data.redis.core.index.Indexed;
 
 @RedisHash("emailAuth")
 @Getter
@@ -13,6 +14,7 @@ import org.springframework.data.redis.core.TimeToLive;
 @Builder
 public class EmailAuthRedisEntity {
     @Id
+    @Indexed
     @Column(name = "email")
     private String email;
 

--- a/src/main/java/com/github/theia/domain/email/EmailAuthRedisEntity.java
+++ b/src/main/java/com/github/theia/domain/email/EmailAuthRedisEntity.java
@@ -7,7 +7,7 @@ import org.springframework.data.redis.core.RedisHash;
 import org.springframework.data.redis.core.TimeToLive;
 import org.springframework.data.redis.core.index.Indexed;
 
-@RedisHash("emailAuth")
+@RedisHash(value = "emailAuth")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor

--- a/src/main/java/com/github/theia/domain/email/EmailAuthRedisEntity.java
+++ b/src/main/java/com/github/theia/domain/email/EmailAuthRedisEntity.java
@@ -22,11 +22,15 @@ public class EmailAuthRedisEntity {
     @Column(name = "authentication")
     private Boolean authentication;
 
+    @Column(name = "attempt_count")
+    private Integer attemptCount;
+
     @TimeToLive
     @Column(name = "expired_at")
     private Long expiredAt;
 
     public void updateCode(String code) {
         this.code = code;
+        this.attemptCount++;
     }
 }

--- a/src/main/java/com/github/theia/domain/email/EmailAuthRedisEntity.java
+++ b/src/main/java/com/github/theia/domain/email/EmailAuthRedisEntity.java
@@ -33,4 +33,8 @@ public class EmailAuthRedisEntity {
         this.code = code;
         this.attemptCount++;
     }
+
+    public void updateAuthentication(Boolean authentication) {
+        this.authentication = authentication;
+    }
 }

--- a/src/main/java/com/github/theia/global/config/EmailConfig.java
+++ b/src/main/java/com/github/theia/global/config/EmailConfig.java
@@ -1,0 +1,66 @@
+package com.github.theia.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+public class EmailConfig {
+
+    @Value("${spring.mail.host}")
+    private String host;
+
+    @Value("${spring.mail.port}")
+    private int port;
+
+    @Value("${spring.mail.username}")
+    private String username;
+
+    @Value("${spring.mail.password}")
+    private String password;
+
+    @Value("${spring.mail.properties.mail.smtp.auth}")
+    private boolean auth;
+
+    @Value("${spring.mail.properties.mail.smtp.starttls.enable}")
+    private boolean starttlsEnable;
+
+    @Value("${spring.mail.properties.mail.smtp.starttls.required}")
+    private boolean starttlsRequired;
+
+    @Value("${spring.mail.properties.mail.smtp.connectiontimeout}")
+    private int connectionTimeout;
+
+    @Value("${spring.mail.properties.mail.smtp.timeout}")
+    private int timeout;
+
+    @Value("${spring.mail.properties.mail.smtp.writetimeout}")
+    private int writeTimeout;
+
+    @Bean
+    public JavaMailSender javaMailSender() {
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+        mailSender.setHost(host);
+        mailSender.setPort(port);
+        mailSender.setUsername(username);
+        mailSender.setPassword(password);
+        mailSender.setDefaultEncoding("UTF-8");
+        mailSender.setJavaMailProperties(getMailProperties());
+
+        return mailSender;
+    }
+
+    private Properties getMailProperties() {
+        Properties properties = new Properties();
+        properties.put("mail.smtp.auth", auth);
+        properties.put("mail.smtp.starttls.enable", starttlsEnable);
+        properties.put("mail.smtp.starttls.required", starttlsRequired);
+        properties.put("mail.smtp.connectiontimeout", connectionTimeout);
+        properties.put("mail.smtp.timeout", timeout);
+        properties.put("mail.smtp.writetimeout", writeTimeout);
+
+        return properties;
+    }
+}

--- a/src/main/java/com/github/theia/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/github/theia/global/error/exception/ErrorCode.java
@@ -12,6 +12,7 @@ public enum ErrorCode {
     DUPLICATE_USER(400, "Duplicated User"),
     NOT_FOUND_USER(404, "Not Found User"),
 
+    ERROR_EMAIL(500, "Email Send Error"),
     ERROR_FEIGN(400, "Kakao Feign Error");
 
     private final int status;

--- a/src/main/java/com/github/theia/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/github/theia/global/error/exception/ErrorCode.java
@@ -12,7 +12,7 @@ public enum ErrorCode {
     DUPLICATE_USER(400, "Duplicated User"),
     NOT_FOUND_USER(404, "Not Found User"),
 
-    NOT_FOUND_EMAIL(400, "Not Found Email"),
+    NOT_FOUND_EMAIL(404, "Not Found Email"),
     NOT_VERIFY_CODE(400, "Not Verify Code"),
     MANY_EMAIL(400, "Many Mail Request"),
 

--- a/src/main/java/com/github/theia/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/github/theia/global/error/exception/ErrorCode.java
@@ -13,6 +13,7 @@ public enum ErrorCode {
     NOT_FOUND_USER(404, "Not Found User"),
 
     ERROR_EMAIL(500, "Email Send Error"),
+    ERROR_CODE(500, "Random Code Error"),
     ERROR_FEIGN(400, "Kakao Feign Error");
 
     private final int status;

--- a/src/main/java/com/github/theia/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/github/theia/global/error/exception/ErrorCode.java
@@ -12,7 +12,10 @@ public enum ErrorCode {
     DUPLICATE_USER(400, "Duplicated User"),
     NOT_FOUND_USER(404, "Not Found User"),
 
+    NOT_FOUND_EMAIL(400, "Not Found Email"),
+    NOT_VERIFY_CODE(400, "Not Verify Code"),
     MANY_EMAIL(400, "Many Mail Request"),
+
     ERROR_EMAIL(500, "Email Send Error"),
     ERROR_CODE(500, "Random Code Error"),
     ERROR_FEIGN(400, "Kakao Feign Error");

--- a/src/main/java/com/github/theia/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/github/theia/global/error/exception/ErrorCode.java
@@ -12,6 +12,7 @@ public enum ErrorCode {
     DUPLICATE_USER(400, "Duplicated User"),
     NOT_FOUND_USER(404, "Not Found User"),
 
+    MANY_EMAIL(400, "Many Mail Request"),
     ERROR_EMAIL(500, "Email Send Error"),
     ERROR_CODE(500, "Random Code Error"),
     ERROR_FEIGN(400, "Kakao Feign Error");

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,18 +31,18 @@ spring:
     refreshExp: ${REFRESHEXP}
 
   mail:
-  host: smtp.gmail.com
-  port: 587
-  username: vvwv309@gmail.com
-  password: ${EMAILPASSWORD}
-  properties:
-    mail:
-      smtp:
-        auth: true
-        starttls:
-          enable: true
-          required: true
-        connectiontimeout: 5000
-        timeout: 5000
-        writetimeout: 5000
+    host: smtp.gmail.com
+    port: 587
+    username: vvwv309@gmail.com
+    password: ${EMAILPASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+            required: true
+          connectiontimeout: 5000
+          timeout: 5000
+          writetimeout: 5000
   auth-code-expiration-millis: 1800000

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,9 +31,9 @@ spring:
     refreshExp: ${REFRESHEXP}
 
   mail:
-    host: smtp.gmail.com
-    port: 587
-    username: vvwv309@gmail.com
+    host: ${EMAILHOST}
+    port: ${EMAILPORT}
+    username: ${EMAILUSERNAME}
     password: ${EMAILPASSWORD}
     properties:
       mail:
@@ -45,4 +45,4 @@ spring:
           connectiontimeout: 5000
           timeout: 5000
           writetimeout: 5000
-  auth-code-expiration-millis: 1800000
+  codeExp: ${CODEEXP}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,3 +29,20 @@ spring:
     refreshKey: ${REFRESHKEY}
     accessExp: ${ACCESSEXP}
     refreshExp: ${REFRESHEXP}
+
+  mail:
+  host: smtp.gmail.com
+  port: 587
+  username: vvwv309@gmail.com
+  password: ${EMAILPASSWORD}
+  properties:
+    mail:
+      smtp:
+        auth: true
+        starttls:
+          enable: true
+          required: true
+        connectiontimeout: 5000
+        timeout: 5000
+        writetimeout: 5000
+  auth-code-expiration-millis: 1800000

--- a/src/main/resources/templates/mail-template.html
+++ b/src/main/resources/templates/mail-template.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>[Theia] 이메일 인증</title>
+</head>
+<body>
+    <h1 th:text="${code}"></h1>
+</body>
+</html>


### PR DESCRIPTION
# 메일 인증 기능 구현

### /email
- `email`을 요청 받아 인증코드를 발급 하여 레디스에 저장 후 메일로 발급한 인증코드를 보낸다.

### /email/verify
- `email`과 `code`를 요청 받아 레디스에 저장되있는 인증코드와 같은지 검증 후 맞다면 해당 레디스 객체의 `authentication` 을 `true`로 변경해주어 회원가입을 진행시킨다.