### PR TITLE
feature/signup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,9 @@ dependencies {
     /* stmp */
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-mail', version: '3.0.5'
     implementation 'javax.mail:javax.mail-api:1.6.2'
+
+    /* s3 */
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 }
 
 dependencyManagement {

--- a/src/main/java/com/github/theia/adapter/auth/in/presentation/AuthController.java
+++ b/src/main/java/com/github/theia/adapter/auth/in/presentation/AuthController.java
@@ -52,6 +52,7 @@ public class AuthController {
     @PostMapping("/login")
     public ResponseEntity<Void> login(HttpServletResponse httpServletResponse,
                                       @RequestBody UserEmailLoginRequest userEmailLoginRequest) {
+
         TokenResponse tokenResponse = authLoginUseCase.login(userEmailLoginRequest);
 
         httpServletResponse.addHeader(ACCESS_HEADER, BEARER_PREFIX + tokenResponse.getAccessToken());

--- a/src/main/java/com/github/theia/adapter/auth/in/presentation/AuthController.java
+++ b/src/main/java/com/github/theia/adapter/auth/in/presentation/AuthController.java
@@ -1,15 +1,18 @@
 package com.github.theia.adapter.auth.in.presentation;
 
+import com.github.theia.adapter.auth.in.presentation.dto.request.UserEmailSignupRequest;
 import com.github.theia.adapter.auth.in.presentation.dto.request.UserKakaoLoginRequest;
 import com.github.theia.adapter.auth.in.presentation.dto.request.UserKakaoSignupRequest;
 import com.github.theia.adapter.auth.in.presentation.dto.respose.LoginUseCaseDto;
 import com.github.theia.adapter.auth.in.presentation.dto.respose.UserLoginResponse;
+import com.github.theia.application.auth.port.in.AuthSignupUseCase;
 import com.github.theia.application.auth.port.in.KakaoSignupUseCase;
 import com.github.theia.application.auth.port.in.KakaoLoginUseCase;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import static com.github.theia.global.security.jwt.JwtTokenProvider.*;
 
@@ -19,10 +22,11 @@ import static com.github.theia.global.security.jwt.JwtTokenProvider.*;
 public class AuthController {
 
     private final KakaoLoginUseCase kakaoLoginUseCase;
-    private final KakaoSignupUseCase authSignupUseCase;
+    private final KakaoSignupUseCase kakaoSignupUseCase;
+    private final AuthSignupUseCase authSignupUseCase;
 
-    @PostMapping("/login")
-    public ResponseEntity<UserLoginResponse> login(HttpServletResponse httpServletResponse,
+    @PostMapping("/kakao")
+    public ResponseEntity<UserLoginResponse> kakaoLogin(HttpServletResponse httpServletResponse,
                                                    @RequestBody UserKakaoLoginRequest userKakaoLoginRequest) {
 
         LoginUseCaseDto loginUseCaseDto = kakaoLoginUseCase.login(userKakaoLoginRequest.getAccessToken());
@@ -33,10 +37,19 @@ public class AuthController {
         return ResponseEntity.ok(new UserLoginResponse(loginUseCaseDto.isSignedUp()));
     }
 
-    @PatchMapping("/signup")
-    public ResponseEntity<Void> signup(@RequestBody UserKakaoSignupRequest userKakaoSignupRequest) {
+    @PatchMapping("/kakao")
+    public ResponseEntity<Void> kakaoSignup(@RequestBody UserKakaoSignupRequest userKakaoSignupRequest) {
 
-        authSignupUseCase.signup(userKakaoSignupRequest);
+        kakaoSignupUseCase.signup(userKakaoSignupRequest);
+
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/signup")
+    public ResponseEntity<Void> signup(@RequestPart(name = "request") UserEmailSignupRequest request,
+                                       @RequestPart(name = "profile_img") MultipartFile profileImg) {
+
+        authSignupUseCase.signup(request, profileImg);
 
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/com/github/theia/adapter/auth/in/presentation/AuthController.java
+++ b/src/main/java/com/github/theia/adapter/auth/in/presentation/AuthController.java
@@ -1,10 +1,13 @@
 package com.github.theia.adapter.auth.in.presentation;
 
+import com.github.theia.adapter.auth.in.presentation.dto.request.UserEmailLoginRequest;
 import com.github.theia.adapter.auth.in.presentation.dto.request.UserEmailSignupRequest;
 import com.github.theia.adapter.auth.in.presentation.dto.request.UserKakaoLoginRequest;
 import com.github.theia.adapter.auth.in.presentation.dto.request.UserKakaoSignupRequest;
 import com.github.theia.adapter.auth.in.presentation.dto.respose.LoginUseCaseDto;
+import com.github.theia.adapter.auth.in.presentation.dto.respose.TokenResponse;
 import com.github.theia.adapter.auth.in.presentation.dto.respose.UserLoginResponse;
+import com.github.theia.application.auth.port.in.AuthLoginUseCase;
 import com.github.theia.application.auth.port.in.AuthSignupUseCase;
 import com.github.theia.application.auth.port.in.KakaoSignupUseCase;
 import com.github.theia.application.auth.port.in.KakaoLoginUseCase;
@@ -23,6 +26,7 @@ public class AuthController {
 
     private final KakaoLoginUseCase kakaoLoginUseCase;
     private final KakaoSignupUseCase kakaoSignupUseCase;
+    private final AuthLoginUseCase authLoginUseCase;
     private final AuthSignupUseCase authSignupUseCase;
 
     @PostMapping("/kakao")
@@ -41,6 +45,17 @@ public class AuthController {
     public ResponseEntity<Void> kakaoSignup(@RequestBody UserKakaoSignupRequest userKakaoSignupRequest) {
 
         kakaoSignupUseCase.signup(userKakaoSignupRequest);
+
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<Void> login(HttpServletResponse httpServletResponse,
+                                      @RequestBody UserEmailLoginRequest userEmailLoginRequest) {
+        TokenResponse tokenResponse = authLoginUseCase.login(userEmailLoginRequest);
+
+        httpServletResponse.addHeader(ACCESS_HEADER, BEARER_PREFIX + tokenResponse.getAccessToken());
+        httpServletResponse.addHeader(REFRESH_HEADER, BEARER_PREFIX + tokenResponse.getRefreshToken());
 
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/com/github/theia/adapter/auth/in/presentation/AuthController.java
+++ b/src/main/java/com/github/theia/adapter/auth/in/presentation/AuthController.java
@@ -4,7 +4,7 @@ import com.github.theia.adapter.auth.in.presentation.dto.request.UserKakaoLoginR
 import com.github.theia.adapter.auth.in.presentation.dto.request.UserKakaoSignupRequest;
 import com.github.theia.adapter.auth.in.presentation.dto.respose.LoginUseCaseDto;
 import com.github.theia.adapter.auth.in.presentation.dto.respose.UserLoginResponse;
-import com.github.theia.application.auth.port.in.AuthSignupUseCase;
+import com.github.theia.application.auth.port.in.KakaoSignupUseCase;
 import com.github.theia.application.auth.port.in.KakaoLoginUseCase;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -19,7 +19,7 @@ import static com.github.theia.global.security.jwt.JwtTokenProvider.*;
 public class AuthController {
 
     private final KakaoLoginUseCase kakaoLoginUseCase;
-    private final AuthSignupUseCase authSignupUseCase;
+    private final KakaoSignupUseCase authSignupUseCase;
 
     @PostMapping("/login")
     public ResponseEntity<UserLoginResponse> login(HttpServletResponse httpServletResponse,

--- a/src/main/java/com/github/theia/adapter/auth/in/presentation/AuthController.java
+++ b/src/main/java/com/github/theia/adapter/auth/in/presentation/AuthController.java
@@ -42,9 +42,10 @@ public class AuthController {
     }
 
     @PatchMapping("/kakao")
-    public ResponseEntity<Void> kakaoSignup(@RequestBody UserKakaoSignupRequest userKakaoSignupRequest) {
+    public ResponseEntity<Void> kakaoSignup(@RequestPart(name = "request") UserKakaoSignupRequest userKakaoSignupRequest,
+                                            @RequestPart(name = "profile_img") MultipartFile profileImg) {
 
-        kakaoSignupUseCase.signup(userKakaoSignupRequest);
+        kakaoSignupUseCase.signup(userKakaoSignupRequest, profileImg);
 
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/com/github/theia/adapter/auth/in/presentation/dto/request/UserEmailLoginRequest.java
+++ b/src/main/java/com/github/theia/adapter/auth/in/presentation/dto/request/UserEmailLoginRequest.java
@@ -1,0 +1,11 @@
+package com.github.theia.adapter.auth.in.presentation.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UserEmailLoginRequest {
+    private String email;
+    private String password;
+}

--- a/src/main/java/com/github/theia/adapter/auth/in/presentation/dto/request/UserEmailSignupRequest.java
+++ b/src/main/java/com/github/theia/adapter/auth/in/presentation/dto/request/UserEmailSignupRequest.java
@@ -1,0 +1,12 @@
+package com.github.theia.adapter.auth.in.presentation.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UserEmailSignupRequest {
+    private String user_email;
+    private String password;
+    private String user_name;
+}

--- a/src/main/java/com/github/theia/adapter/auth/in/presentation/dto/request/UserEmailSignupRequest.java
+++ b/src/main/java/com/github/theia/adapter/auth/in/presentation/dto/request/UserEmailSignupRequest.java
@@ -6,7 +6,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class UserEmailSignupRequest {
-    private String user_email;
+    private String email;
     private String password;
     private String user_name;
 }

--- a/src/main/java/com/github/theia/adapter/auth/in/presentation/dto/request/UserEmailSignupRequest.java
+++ b/src/main/java/com/github/theia/adapter/auth/in/presentation/dto/request/UserEmailSignupRequest.java
@@ -8,5 +8,5 @@ import lombok.NoArgsConstructor;
 public class UserEmailSignupRequest {
     private String email;
     private String password;
-    private String user_name;
+    private String userName;
 }

--- a/src/main/java/com/github/theia/adapter/user/in/persentation/dto/response/UserInfoResponse.java
+++ b/src/main/java/com/github/theia/adapter/user/in/persentation/dto/response/UserInfoResponse.java
@@ -12,4 +12,5 @@ import lombok.NoArgsConstructor;
 public class UserInfoResponse {
     private Long userId;
     private String userName;
+    private String userProfileUrl;
 }

--- a/src/main/java/com/github/theia/application/auth/port/in/AuthLoginUseCase.java
+++ b/src/main/java/com/github/theia/application/auth/port/in/AuthLoginUseCase.java
@@ -1,0 +1,8 @@
+package com.github.theia.application.auth.port.in;
+
+import com.github.theia.adapter.auth.in.presentation.dto.request.UserEmailLoginRequest;
+import com.github.theia.adapter.auth.in.presentation.dto.respose.TokenResponse;
+
+public interface AuthLoginUseCase {
+    TokenResponse login(UserEmailLoginRequest userEmailLoginRequest);
+}

--- a/src/main/java/com/github/theia/application/auth/port/in/AuthSignupUseCase.java
+++ b/src/main/java/com/github/theia/application/auth/port/in/AuthSignupUseCase.java
@@ -1,7 +1,8 @@
 package com.github.theia.application.auth.port.in;
 
 import com.github.theia.adapter.auth.in.presentation.dto.request.UserEmailSignupRequest;
+import org.springframework.web.multipart.MultipartFile;
 
 public interface AuthSignupUseCase {
-    void signup(UserEmailSignupRequest userEmailSignupRequest);
+    void signup(UserEmailSignupRequest userEmailSignupRequest, MultipartFile profile_img);
 }

--- a/src/main/java/com/github/theia/application/auth/port/in/AuthSignupUseCase.java
+++ b/src/main/java/com/github/theia/application/auth/port/in/AuthSignupUseCase.java
@@ -4,5 +4,5 @@ import com.github.theia.adapter.auth.in.presentation.dto.request.UserEmailSignup
 import org.springframework.web.multipart.MultipartFile;
 
 public interface AuthSignupUseCase {
-    void signup(UserEmailSignupRequest userEmailSignupRequest, MultipartFile profile_img);
+    void signup(UserEmailSignupRequest userEmailSignupRequest, MultipartFile profileImg);
 }

--- a/src/main/java/com/github/theia/application/auth/port/in/AuthSignupUseCase.java
+++ b/src/main/java/com/github/theia/application/auth/port/in/AuthSignupUseCase.java
@@ -1,7 +1,7 @@
 package com.github.theia.application.auth.port.in;
 
-import com.github.theia.adapter.auth.in.presentation.dto.request.UserKakaoSignupRequest;
+import com.github.theia.adapter.auth.in.presentation.dto.request.UserEmailSignupRequest;
 
 public interface AuthSignupUseCase {
-    void signup(UserKakaoSignupRequest userKakaoSignupRequest);
+    void signup(UserEmailSignupRequest userEmailSignupRequest);
 }

--- a/src/main/java/com/github/theia/application/auth/port/in/KakaoSignupUseCase.java
+++ b/src/main/java/com/github/theia/application/auth/port/in/KakaoSignupUseCase.java
@@ -1,0 +1,7 @@
+package com.github.theia.application.auth.port.in;
+
+import com.github.theia.adapter.auth.in.presentation.dto.request.UserKakaoSignupRequest;
+
+public interface KakaoSignupUseCase {
+    void signup(UserKakaoSignupRequest userKakaoSignupRequest);
+}

--- a/src/main/java/com/github/theia/application/auth/port/in/KakaoSignupUseCase.java
+++ b/src/main/java/com/github/theia/application/auth/port/in/KakaoSignupUseCase.java
@@ -1,7 +1,8 @@
 package com.github.theia.application.auth.port.in;
 
 import com.github.theia.adapter.auth.in.presentation.dto.request.UserKakaoSignupRequest;
+import org.springframework.web.multipart.MultipartFile;
 
 public interface KakaoSignupUseCase {
-    void signup(UserKakaoSignupRequest userKakaoSignupRequest);
+    void signup(UserKakaoSignupRequest userKakaoSignupRequest, MultipartFile profileImg);
 }

--- a/src/main/java/com/github/theia/application/auth/port/service/AuthService.java
+++ b/src/main/java/com/github/theia/application/auth/port/service/AuthService.java
@@ -108,10 +108,10 @@ public class AuthService implements KakaoLoginUseCase, KakaoSignupUseCase, AuthS
 
     @Override
     @Transactional
-    public void signup(UserEmailSignupRequest userEmailSignupRequest, MultipartFile profile_img) {
+    public void signup(UserEmailSignupRequest userEmailSignupRequest, MultipartFile profileImg) {
         String email = userEmailSignupRequest.getEmail();
         String password = passwordEncoder.encode(userEmailSignupRequest.getPassword());
-        String user_name = userEmailSignupRequest.getUser_name();
+        String user_name = userEmailSignupRequest.getUserName();
         String user_profile_url;
 
         EmailAuthRedisEntity emailAuth = loadEmailAuthByEmailPort.findByEmail(email)
@@ -121,7 +121,7 @@ public class AuthService implements KakaoLoginUseCase, KakaoSignupUseCase, AuthS
             throw new TheiaException(UNAUTHORIZATION_EMAIL);
 
         try {
-            user_profile_url = s3Manager.uploadImages(profile_img);
+            user_profile_url = s3Manager.uploadImages(profileImg);
         } catch (IOException e) {
             throw new TheiaException(ERROR_S3);
         }

--- a/src/main/java/com/github/theia/application/auth/port/service/AuthService.java
+++ b/src/main/java/com/github/theia/application/auth/port/service/AuthService.java
@@ -5,7 +5,7 @@ import com.github.theia.adapter.auth.in.presentation.dto.respose.KaKaoInfo;
 import com.github.theia.adapter.auth.in.presentation.dto.respose.LoginUseCaseDto;
 import com.github.theia.adapter.auth.in.presentation.dto.respose.TokenResponse;
 import com.github.theia.application.auth.port.in.KakaoLoginUseCase;
-import com.github.theia.application.auth.port.in.AuthSignupUseCase;
+import com.github.theia.application.auth.port.in.KakaoSignupUseCase;
 import com.github.theia.application.auth.port.out.*;
 import com.github.theia.domain.refresh.RefreshTokenRedisEntity;
 import com.github.theia.domain.user.UserEntity;
@@ -24,7 +24,7 @@ import static com.github.theia.global.error.exception.ErrorCode.*;
 
 @Service
 @RequiredArgsConstructor
-public class AuthService implements KakaoLoginUseCase, AuthSignupUseCase {
+public class AuthService implements KakaoLoginUseCase, KakaoSignupUseCase {
 
     private final SaveUserPort saveUserPort;
     private final IsUserByNamePort isUserByNamePort;

--- a/src/main/java/com/github/theia/application/auth/port/service/AuthService.java
+++ b/src/main/java/com/github/theia/application/auth/port/service/AuthService.java
@@ -1,30 +1,38 @@
 package com.github.theia.application.auth.port.service;
 
+import com.github.theia.adapter.auth.in.presentation.dto.request.UserEmailSignupRequest;
 import com.github.theia.adapter.auth.in.presentation.dto.request.UserKakaoSignupRequest;
 import com.github.theia.adapter.auth.in.presentation.dto.respose.KaKaoInfo;
 import com.github.theia.adapter.auth.in.presentation.dto.respose.LoginUseCaseDto;
 import com.github.theia.adapter.auth.in.presentation.dto.respose.TokenResponse;
+import com.github.theia.application.auth.port.in.AuthSignupUseCase;
 import com.github.theia.application.auth.port.in.KakaoLoginUseCase;
 import com.github.theia.application.auth.port.in.KakaoSignupUseCase;
 import com.github.theia.application.auth.port.out.*;
+import com.github.theia.application.email.port.out.LoadEmailAuthByEmailPort;
+import com.github.theia.domain.email.EmailAuthRedisEntity;
 import com.github.theia.domain.refresh.RefreshTokenRedisEntity;
 import com.github.theia.domain.user.UserEntity;
 import com.github.theia.facade.UserFacade;
 import com.github.theia.global.error.exception.TheiaException;
 import com.github.theia.global.feign.client.KakaoInformationClient;
 import com.github.theia.global.security.jwt.JwtTokenProvider;
+import com.github.theia.s3.S3Manager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.net.URI;
 
 import static com.github.theia.global.error.exception.ErrorCode.*;
 
 @Service
 @RequiredArgsConstructor
-public class AuthService implements KakaoLoginUseCase, KakaoSignupUseCase {
+public class AuthService implements KakaoLoginUseCase, KakaoSignupUseCase, AuthSignupUseCase {
 
     private final SaveUserPort saveUserPort;
     private final IsUserByNamePort isUserByNamePort;
@@ -33,6 +41,9 @@ public class AuthService implements KakaoLoginUseCase, KakaoSignupUseCase {
     private final UserFacade userFacade;
     private final JwtTokenProvider jwtTokenProvider;
     private final KakaoInformationClient kakaoInformationClient;
+    private final LoadEmailAuthByEmailPort loadEmailAuthByEmailPort;
+    private final PasswordEncoder passwordEncoder;
+    private final S3Manager s3Manager;
 
     @Value("${spring.kakao.userApiUrl}")
     private String kakaoUserApiUrl;
@@ -91,6 +102,36 @@ public class AuthService implements KakaoLoginUseCase, KakaoSignupUseCase {
                 .orElseThrow(() -> new TheiaException(NOT_FOUND_USER));
 
         newUser.editUserName(userKakaoSignupRequest.getUserName());
+
+        saveUserPort.save(newUser);
+    }
+
+    @Override
+    @Transactional
+    public void signup(UserEmailSignupRequest userEmailSignupRequest, MultipartFile profile_img) {
+        String email = userEmailSignupRequest.getEmail();
+        String password = passwordEncoder.encode(userEmailSignupRequest.getPassword());
+        String user_name = userEmailSignupRequest.getUser_name();
+        String user_profile_url;
+
+        EmailAuthRedisEntity emailAuth = loadEmailAuthByEmailPort.findByEmail(email)
+                .orElseThrow(() -> new TheiaException(NOT_FOUND_EMAIL));
+
+        if (!emailAuth.getAuthentication())
+            throw new TheiaException(UNAUTHORIZATION_EMAIL);
+
+        try {
+            user_profile_url = s3Manager.uploadImages(profile_img);
+        } catch (IOException e) {
+            throw new TheiaException(ERROR_S3);
+        }
+
+        UserEntity newUser = UserEntity.builder()
+                    .userEmail(email)
+                    .userName(user_name)
+                    .password(password)
+                    .userProfileUrl(user_profile_url)
+                .build();
 
         saveUserPort.save(newUser);
     }

--- a/src/main/java/com/github/theia/application/user/port/service/UserService.java
+++ b/src/main/java/com/github/theia/application/user/port/service/UserService.java
@@ -23,6 +23,7 @@ public class UserService implements UserInfoUseCase {
         return UserInfoResponse.builder()
                 .userId(user.getUserSeq())
                 .userName(user.getUserName())
+                .userProfileUrl(user.getUserProfileUrl())
                 .build();
     }
 }

--- a/src/main/java/com/github/theia/domain/user/UserEntity.java
+++ b/src/main/java/com/github/theia/domain/user/UserEntity.java
@@ -29,4 +29,8 @@ public class UserEntity {
     public void editUserName(String userName) {
         this.userName = userName;
     }
+
+    public void editUserProfileUrl(String userProfileUrl) {
+        this.userProfileUrl = userProfileUrl;
+    }
 }

--- a/src/main/java/com/github/theia/domain/user/UserEntity.java
+++ b/src/main/java/com/github/theia/domain/user/UserEntity.java
@@ -20,6 +20,12 @@ public class UserEntity {
     @Column(name = "user_email", nullable = false, unique = true)
     private String userEmail;
 
+    @Column(name = "password")
+    private String password;
+
+    @Column(name = "user_profile_url", nullable = false)
+    private String userProfileUrl;
+
     public void editUserName(String userName) {
         this.userName = userName;
     }

--- a/src/main/java/com/github/theia/global/config/SecurityConfig.java
+++ b/src/main/java/com/github/theia/global/config/SecurityConfig.java
@@ -26,12 +26,6 @@ public class SecurityConfig {
         return new BCryptPasswordEncoder();
     }
 
-//    @Bean
-//    public WebSecurityCustomizer configure() {
-//        return (web) -> web.ignoring()
-//                .requestMatchers(toH2Console());
-//    }
-
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http.csrf((csrf) -> csrf.disable());

--- a/src/main/java/com/github/theia/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/github/theia/global/error/exception/ErrorCode.java
@@ -13,9 +13,11 @@ public enum ErrorCode {
     NOT_FOUND_USER(404, "Not Found User"),
 
     NOT_FOUND_EMAIL(404, "Not Found Email"),
+    UNAUTHORIZATION_EMAIL(401, "Unauthorization Email"),
     NOT_VERIFY_CODE(400, "Not Verify Code"),
     MANY_EMAIL(400, "Many Mail Request"),
 
+    ERROR_S3(500, "S3 Error"),
     ERROR_EMAIL(500, "Email Send Error"),
     ERROR_CODE(500, "Random Code Error"),
     ERROR_FEIGN(400, "Kakao Feign Error");

--- a/src/main/java/com/github/theia/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/github/theia/global/error/exception/ErrorCode.java
@@ -11,6 +11,7 @@ public enum ErrorCode {
     INVALID_JWT(401, "Invalid Jwt"),
     DUPLICATE_USER(400, "Duplicated User"),
     NOT_FOUND_USER(404, "Not Found User"),
+    NOT_MATCH_PASSWORD(400, "Not Match Password"),
 
     NOT_FOUND_EMAIL(404, "Not Found Email"),
     UNAUTHORIZATION_EMAIL(401, "Unauthorization Email"),

--- a/src/main/java/com/github/theia/global/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/github/theia/global/security/jwt/JwtTokenProvider.java
@@ -36,14 +36,14 @@ public class JwtTokenProvider {
     public static final String REFRESH_HEADER = "Refersh-Token";
     public static final String BEARER_PREFIX = "Bearer ";
 
-    public TokenResponse getAccessToken(String email) {
-        String accessToken = generateToken(email, accessExp);
+    public TokenResponse getToken(String email) {
+        String accessToken = generateAccessToken(email, accessExp);
         String refreshToken = generateRefrshToken(email, refreshExp);
 
         return new TokenResponse(accessToken, refreshToken);
     }
 
-    private String generateToken(String email, long expiration) {
+    private String generateAccessToken(String email, long expiration) {
         return Jwts.builder().signWith(SignatureAlgorithm.HS256, secretKey)
                 .setSubject(email)
                 .setHeaderParam("typ", ACCESS_KEY)

--- a/src/main/java/com/github/theia/s3/S3Config.java
+++ b/src/main/java/com/github/theia/s3/S3Config.java
@@ -1,0 +1,33 @@
+package com.github.theia.s3;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+
+    @Value("${spring.cloud.aws.credentials.accessKey}")
+    private String accessKey;
+
+    @Value("${spring.cloud.aws.credentials.secretKey}")
+    private String secretKey;
+
+    @Value("${spring.cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3 amazonS3() {
+        AWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
+
+        return AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                .build();
+    }
+}

--- a/src/main/java/com/github/theia/s3/S3Manager.java
+++ b/src/main/java/com/github/theia/s3/S3Manager.java
@@ -1,0 +1,44 @@
+package com.github.theia.s3;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@RequiredArgsConstructor
+@Component
+public class S3Manager {
+
+    @Value("${spring.cloud.aws.s3.bucket}")
+    private String bucketName;
+    private final AmazonS3 amazonS3;
+
+    public String uploadImages(MultipartFile image) throws IOException {
+
+        String fileName = UUID.randomUUID() + image.getOriginalFilename();
+        PutObjectRequest request = new PutObjectRequest(
+                bucketName, fileName, image.getInputStream(), getObjectMetadata(image)
+        ).withCannedAcl(CannedAccessControlList.PublicRead);
+        amazonS3.putObject(request);
+
+        return getFileUrl(fileName);
+    }
+
+    private ObjectMetadata getObjectMetadata(MultipartFile image) {
+        ObjectMetadata objectMetadata = new ObjectMetadata();
+        objectMetadata.setContentLength(image.getSize());
+        objectMetadata.setContentType(image.getContentType());
+        return objectMetadata;
+    }
+
+    public String getFileUrl(String fileName) {
+        return amazonS3.getUrl(bucketName, fileName).toString();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -62,5 +62,5 @@ spring:
 
   servlet:
     multipart:
-      max-file-size: 20MB
-      max-request-size: 20MB
+      max-file-size: 5MB
+      max-request-size: 5MB

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -46,3 +46,21 @@ spring:
           timeout: 5000
           writetimeout: 5000
   codeExp: ${CODEEXP}
+
+
+  cloud:
+    aws:
+      credentials:
+        accessKey: ${AWS_ACCESS_KEY}
+        secretKey: ${AWS_SECRET_ACCESS_KEY}
+      s3:
+        bucket: ${BUCKET}
+      region:
+        static: ${STATIC}
+      stack:
+        auto: false
+
+  servlet:
+    multipart:
+      max-file-size: 20MB
+      max-request-size: 20MB


### PR DESCRIPTION
# 이메일 회원가입 & 로그인 기능 구현

### /signup
- request: (`email`, `password`, `user_name`), profile_img: `profile_img`를 멀티파트 형식으로 요청받습니다.
- `redis`에서 요청으로 온 이메일이 인증된 이메일인지 검증 후 회원가입이 완료됩니다.

### /login
- `email`, `password`를 요청 받아 검증 후 토큰을 발급합니다.

#### 변경사항
- 유저 컬럼에 프로필 이미지를 추가하였습니다.
- 카카오 회원가입 요청 스펙에 이미지를 받게 멀티파트로 변경하였습니다.